### PR TITLE
Fix babel transpilation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["stage-0", "env"]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zapp-pipes-provider-apdotstudiopro",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapp-pipes-provider-apdotstudiopro",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Zapp Provider for dotstudioPRO made by Applicaster",
   "main": "lib/index.js",
   "scripts": {

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -3,10 +3,10 @@
   "platform": null,
   "author_name": "Applicaster",
   "author_email": "zapp@applicaster.com",
-  "manifest_version": "0.2.0",
+  "manifest_version": "0.2.1",
   "name": "DotStudioPro By Applicaster",
   "dependency_name": "zapp-pipes-provider-apdotstudiopro",
-  "dependency_version": "0.2.0",
+  "dependency_version": "0.2.1",
   "dependency_repository_url": [
     "https://github.com/applicaster/zapp-pipes-provider-apdotstudiopro"
   ],


### PR DESCRIPTION
This PR fixes the babel transpilation config in order to properly apply the required babel config for DSP

This prevents the plugin from crashing in the zapp-pipes server or the app.

On order to restore functionality of the zapp-pipes server, a new version was deployed with this fix (0.2.1)